### PR TITLE
[4.0.r1] aidl: fuzzer: Update hal path

### DIFF
--- a/aidl/fuzzer/Android.bp
+++ b/aidl/fuzzer/Android.bp
@@ -22,6 +22,6 @@ cc_fuzz {
     ],
 
     include_dirs: [
-        "hardware/qcom/bootctrl/aidl",
+        "vendor/qcom/opensource/bootctrl/aidl",
     ],
 }


### PR DESCRIPTION
We store this hal in the vendor/qcom/opensource directory.